### PR TITLE
Add some missing injects to ServerGamePacketListenerImpl

### DIFF
--- a/src/main/java/xyz/bluspring/kilt/forgeinjects/client/multiplayer/MultiPlayerGameModeInject.java
+++ b/src/main/java/xyz/bluspring/kilt/forgeinjects/client/multiplayer/MultiPlayerGameModeInject.java
@@ -26,12 +26,10 @@ import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.GameType;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelReader;
-import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.SoundType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.phys.BlockHitResult;
-import net.minecraft.world.phys.EntityHitResult;
 import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.common.extensions.IForgeBlock;
 import net.minecraftforge.event.ForgeEventFactory;
@@ -204,17 +202,5 @@ public abstract class MultiPlayerGameModeInject {
         if (stack2.isEmpty()) {
             ForgeEventFactory.onPlayerDestroyItem(player, stack, interactionHand);
         }
-    }
-
-    @Inject(method = "interactAt", at = @At("TAIL"), cancellable = true)
-    private void kilt$handleInteractEntityEvent(Player player, Entity target, EntityHitResult ray, InteractionHand hand, CallbackInfoReturnable<InteractionResult> cir) {
-        if (this.localPlayerMode == GameType.SPECTATOR) {
-            cir.setReturnValue(InteractionResult.PASS);
-            return;
-        }
-
-        var cancelResult = ForgeHooks.onInteractEntityAt(player, target, ray, hand);
-        if (cancelResult != null)
-            cir.setReturnValue(cancelResult);
     }
 }

--- a/src/main/java/xyz/bluspring/kilt/forgeinjects/server/network/ServerGamePacketListenerImplInject.java
+++ b/src/main/java/xyz/bluspring/kilt/forgeinjects/server/network/ServerGamePacketListenerImplInject.java
@@ -5,19 +5,17 @@ import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.llamalad7.mixinextras.sugar.Cancellable;
-import com.llamalad7.mixinextras.sugar.Share;
+import com.llamalad7.mixinextras.sugar.Local;
 import com.llamalad7.mixinextras.sugar.ref.LocalRef;
 import net.minecraft.Util;
 import net.minecraft.network.Connection;
 import net.minecraft.network.chat.ChatDecorator;
 import net.minecraft.network.protocol.game.ServerboundCustomPayloadPacket;
-import net.minecraft.network.protocol.game.ServerboundPlayerActionPacket;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.network.ServerGamePacketListenerImpl;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.common.ForgeHooks;
-import net.minecraftforge.event.entity.living.LivingSwapItemsEvent;
 import net.minecraftforge.network.NetworkHooks;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -33,43 +31,16 @@ public abstract class ServerGamePacketListenerImplInject {
     @Shadow
     public ServerPlayer player;
 
-    @Inject(
-        method = "handlePlayerAction",
-        at = @At(
-            value = "INVOKE",
-            target = "Lnet/minecraft/server/level/ServerPlayer;setItemInHand(Lnet/minecraft/world/InteractionHand;Lnet/minecraft/world/item/ItemStack;)V",
-            ordinal = 0
-        ),
-        cancellable = true
-    )
-    private void kilt$handleSendPlayerSwapItemsEvent(
-        ServerboundPlayerActionPacket packet, CallbackInfo ci, @Share("event") LocalRef<LivingSwapItemsEvent.Hands> event
-    ) {
-        event.set(ForgeHooks.onLivingSwapHandItems(player));
-        if (event.get().isCanceled()) {
+    @WrapOperation(method = "handlePlayerAction", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/level/ServerPlayer;setItemInHand(Lnet/minecraft/world/InteractionHand;Lnet/minecraft/world/item/ItemStack;)V", ordinal = 0))
+    private void kilt$handleLivingSwapHandItemsEvent(ServerPlayer instance, InteractionHand interactionHand, ItemStack itemStack, Operation<Void> original, @Cancellable CallbackInfo ci, @Local LocalRef<ItemStack> offhandStack) {
+        var event = ForgeHooks.kilt$onLivingSwapHandItems(this.player, offhandStack.get(), itemStack);
+        if (event.isCanceled()) {
             ci.cancel();
+            return;
         }
-    }
 
-    @WrapOperation(
-        method = "handlePlayerAction",
-        at = @At(
-            value = "INVOKE",
-            target = "Lnet/minecraft/server/level/ServerPlayer;setItemInHand(Lnet/minecraft/world/InteractionHand;Lnet/minecraft/world/item/ItemStack;)V"
-        )
-    )
-    private void kilt$updateSwappedItemsFromEvent(
-        ServerPlayer instance, InteractionHand hand, ItemStack itemStack, Operation<Void> original,
-        @Share("event") LocalRef<LivingSwapItemsEvent.Hands> eventRef
-    ) {
-        var event = eventRef.get();
-
-        if (hand == InteractionHand.OFF_HAND && !event.getItemSwappedToOffHand().equals(itemStack)) {
-            itemStack = event.getItemSwappedToOffHand();
-        } else if (hand == InteractionHand.MAIN_HAND && !event.getItemSwappedToMainHand().equals(itemStack)) {
-            itemStack = event.getItemSwappedToMainHand();
-        }
-        original.call(instance, hand, itemStack);
+        original.call(instance, interactionHand, event.getItemSwappedToOffHand());
+        offhandStack.set(event.getItemSwappedToMainHand());
     }
 
     @ModifyExpressionValue(

--- a/src/main/java/xyz/bluspring/kilt/forgeinjects/server/network/ServerGamePacketListenerImplInject.java
+++ b/src/main/java/xyz/bluspring/kilt/forgeinjects/server/network/ServerGamePacketListenerImplInject.java
@@ -1,18 +1,20 @@
 // TRACKED HASH: 1886f30859644767992d36dcae1264c9b9614cd4
 package xyz.bluspring.kilt.forgeinjects.server.network;
 
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Cancellable;
 import com.llamalad7.mixinextras.sugar.Share;
 import com.llamalad7.mixinextras.sugar.ref.LocalRef;
+import net.minecraft.Util;
 import net.minecraft.network.Connection;
+import net.minecraft.network.chat.ChatDecorator;
 import net.minecraft.network.protocol.game.ServerboundCustomPayloadPacket;
 import net.minecraft.network.protocol.game.ServerboundPlayerActionPacket;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.network.ServerGamePacketListenerImpl;
 import net.minecraft.world.InteractionHand;
-import net.minecraft.world.entity.EquipmentSlot;
-import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.event.entity.living.LivingSwapItemsEvent;
@@ -68,6 +70,36 @@ public abstract class ServerGamePacketListenerImplInject {
             itemStack = event.getItemSwappedToMainHand();
         }
         original.call(instance, hand, itemStack);
+    }
+
+    @ModifyExpressionValue(
+        method = "method_44900",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/server/MinecraftServer;getChatDecorator()Lnet/minecraft/network/chat/ChatDecorator;"
+        )
+    )
+    private ChatDecorator kilt$combineChatDecorators(ChatDecorator fabricDecorator) {
+        var forgeDecorator = ForgeHooks.getServerChatSubmittedDecorator();
+        return (player, message) -> fabricDecorator.decorate(player, message).thenComposeAsync(
+            fabricMessage -> forgeDecorator.decorate(player, fabricMessage),
+            Util.backgroundExecutor()
+        );
+    }
+
+    @ModifyExpressionValue(
+        method = "method_45064",
+        at = @At(
+            value = "INVOKE",
+            target = "Ljava/util/concurrent/CompletableFuture;join()Ljava/lang/Object;",
+            ordinal = 0
+        )
+    )
+    private <T> T kilt$skipChatWhenMessageNull(T original, @Cancellable CallbackInfo ci) {
+        if (original == null) {
+            ci.cancel();
+        }
+        return original;
     }
 
     @Inject(at = @At("HEAD"), method = "handleCustomPayload", cancellable = true)

--- a/src/main/java/xyz/bluspring/kilt/forgeinjects/server/network/ServerGamePacketListenerImplInject.java
+++ b/src/main/java/xyz/bluspring/kilt/forgeinjects/server/network/ServerGamePacketListenerImplInject.java
@@ -1,9 +1,21 @@
 // TRACKED HASH: 1886f30859644767992d36dcae1264c9b9614cd4
 package xyz.bluspring.kilt.forgeinjects.server.network;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Share;
+import com.llamalad7.mixinextras.sugar.ref.LocalRef;
 import net.minecraft.network.Connection;
 import net.minecraft.network.protocol.game.ServerboundCustomPayloadPacket;
+import net.minecraft.network.protocol.game.ServerboundPlayerActionPacket;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.network.ServerGamePacketListenerImpl;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.common.ForgeHooks;
+import net.minecraftforge.event.entity.living.LivingSwapItemsEvent;
 import net.minecraftforge.network.NetworkHooks;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -15,6 +27,48 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(ServerGamePacketListenerImpl.class)
 public abstract class ServerGamePacketListenerImplInject {
     @Shadow @Final public Connection connection;
+
+    @Shadow
+    public ServerPlayer player;
+
+    @Inject(
+        method = "handlePlayerAction",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/server/level/ServerPlayer;setItemInHand(Lnet/minecraft/world/InteractionHand;Lnet/minecraft/world/item/ItemStack;)V",
+            ordinal = 0
+        ),
+        cancellable = true
+    )
+    private void kilt$handleSendPlayerSwapItemsEvent(
+        ServerboundPlayerActionPacket packet, CallbackInfo ci, @Share("event") LocalRef<LivingSwapItemsEvent.Hands> event
+    ) {
+        event.set(ForgeHooks.onLivingSwapHandItems(player));
+        if (event.get().isCanceled()) {
+            ci.cancel();
+        }
+    }
+
+    @WrapOperation(
+        method = "handlePlayerAction",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/server/level/ServerPlayer;setItemInHand(Lnet/minecraft/world/InteractionHand;Lnet/minecraft/world/item/ItemStack;)V"
+        )
+    )
+    private void kilt$updateSwappedItemsFromEvent(
+        ServerPlayer instance, InteractionHand hand, ItemStack itemStack, Operation<Void> original,
+        @Share("event") LocalRef<LivingSwapItemsEvent.Hands> eventRef
+    ) {
+        var event = eventRef.get();
+
+        if (hand == InteractionHand.OFF_HAND && !event.getItemSwappedToOffHand().equals(itemStack)) {
+            itemStack = event.getItemSwappedToOffHand();
+        } else if (hand == InteractionHand.MAIN_HAND && !event.getItemSwappedToMainHand().equals(itemStack)) {
+            itemStack = event.getItemSwappedToMainHand();
+        }
+        original.call(instance, hand, itemStack);
+    }
 
     @Inject(at = @At("HEAD"), method = "handleCustomPayload", cancellable = true)
     public void kilt$handleCustomPayload(ServerboundCustomPayloadPacket packet, CallbackInfo ci) {

--- a/src/main/kotlin/xyz/bluspring/kilt/Kilt.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/Kilt.kt
@@ -3,6 +3,7 @@ package xyz.bluspring.kilt
 import com.google.gson.GsonBuilder
 import io.github.fabricators_of_create.porting_lib.core.event.BaseEvent
 import io.github.fabricators_of_create.porting_lib.entity.events.*
+import io.github.fabricators_of_create.porting_lib.entity.events.PlayerInteractionEvents
 import io.github.fabricators_of_create.porting_lib.event.common.BlockEvents
 import io.github.fabricators_of_create.porting_lib.event.common.ExplosionEvents
 import net.fabricmc.api.ModInitializer
@@ -176,6 +177,14 @@ class Kilt : ModInitializer {
         EntityElytraEvents.CUSTOM.register { entity, tickElytra ->
             val chestPiece = entity.getItemBySlot(EquipmentSlot.CHEST)
             chestPiece.canElytraFly(entity) && chestPiece.elytraFlightTick(entity, entity.fallFlyingTicks)
+        }
+
+        PlayerInteractionEvents.INTERACT_ENTITY_POSITIONED.register { player, entity, vec3, hand ->
+            val result = ForgeHooks.onInteractEntityAt(player, entity, vec3, hand)
+            if (result != null) {
+                return@register result
+            }
+            return@register null
         }
     }
 


### PR DESCRIPTION
When checking why the ChatEvent was never fired, I noticed that some other injects for ServerGamePacketListenerImpl were missing. For example, the hand item swap event and positioned player interact events were never fired on the server side. 

For the positioned player interact event I thought it made more sense to use the Porting Lib event, so I removed the client-specific inject for that and let Porting Lib handle both sides.

Closes #998