### PR TITLE
Update TypedIngredientMixin to support the latest version of JEI.

### DIFF
--- a/compat/fabric-compats/gradle.properties
+++ b/compat/fabric-compats/gradle.properties
@@ -21,7 +21,7 @@ amecs_key_modifiers_version = 1.0.2
 emi_version = 1.1.22+1.21.1
 
 # https://modrinth.com/mod/jei/versions?l=fabric&g=1.21.1
-jei_version = 19.22.0.315
+jei_version = 19.54.0.427
 
 # https://modrinth.com/mod/rei/versions?l=fabric&g=1.21.1
 rei_version = 16.0.799

--- a/compat/fabric-compats/src/main/java/xyz/bluspring/kilt/compat/fabric/mixin/jei/TypedIngredientMixin.java
+++ b/compat/fabric-compats/src/main/java/xyz/bluspring/kilt/compat/fabric/mixin/jei/TypedIngredientMixin.java
@@ -4,13 +4,14 @@ import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.moulberry.mixinconstraints.annotations.IfModLoaded;
 import mezz.jei.api.fabric.ingredients.fluids.IJeiFluidIngredient;
-import mezz.jei.library.ingredients.TypedIngredient;
 import net.neoforged.neoforge.fluids.FluidStack;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
 import xyz.bluspring.kilt.util.neoforge.fluid.FluidTransferUtils;
 
+@Pseudo
 @IfModLoaded("jei")
-@Mixin(TypedIngredient.class)
+@Mixin(targets = {"mezz.jei.common.ingredients.TypedIngredient", "mezz.jei.library.ingredients.TypedIngredient"})
 public class TypedIngredientMixin<T> {
 
     @WrapMethod(method = "getIngredient", remap = false)


### PR DESCRIPTION
Should still be backwards-compatible with any older versions that were working.