### PR TITLE
Update TypedIngredientMixin to support the latest version of JEI [1.20.1].

### DIFF
--- a/compat/fabric-compats/src/main/java/xyz/bluspring/kilt/compat/fabric/mixin/jei/TypedIngredientMixin.java
+++ b/compat/fabric-compats/src/main/java/xyz/bluspring/kilt/compat/fabric/mixin/jei/TypedIngredientMixin.java
@@ -4,13 +4,14 @@ import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.moulberry.mixinconstraints.annotations.IfModLoaded;
 import mezz.jei.api.fabric.ingredients.fluids.IJeiFluidIngredient;
-import mezz.jei.library.ingredients.TypedIngredient;
 import net.minecraftforge.fluids.FluidStack;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
 import xyz.bluspring.kilt.util.forge.fluid.FluidTransferUtils;
 
+@Pseudo
 @IfModLoaded("jei")
-@Mixin(TypedIngredient.class)
+@Mixin(targets = {"mezz.jei.common.ingredients.TypedIngredient", "mezz.jei.library.ingredients.TypedIngredient"})
 public class TypedIngredientMixin<T> {
 
     @WrapMethod(method = "getIngredient", remap = false)


### PR DESCRIPTION
Same as #1002 but for 1.20.1. I decided not to bump JEI here since that would require bumping loom to 1.17.